### PR TITLE
Fix Block Checkout flow submitting state blocking payment execution

### DIFF
--- a/assets/js/bytenft.js
+++ b/assets/js/bytenft.js
@@ -213,7 +213,7 @@
                     self.openPopupImmediately();
 
                     // Start block flow
-                    self.handleBlockCheckout($form);
+                    self.createBlockOrder($form);
 
                 },
                 true
@@ -246,13 +246,64 @@
             );
         },
 
-        handleBlockCheckout: function ($form) {
+        createBlockOrder: function ($form) {
 
             const self = this;
 
-            if (self.state.submitting) {
-                return;
-            }
+            self.state.submitting = true;
+
+            $.ajax({
+
+                type: 'POST',
+
+                url: bytenft_params.ajax_url,
+
+                data: {
+                    action: 'bytenft_create_block_order',
+                    nonce: bytenft_params.bytenft_nonce,
+                    checkout_data: $form.serialize()
+                },
+
+                success: function (response) {
+
+                    console.log('[Bytenft] create order response', response);
+
+                    if (!response || !response.success || !response.data?.order_id) {
+
+                        self.showCheckoutError(
+                            response?.message || 'Unable to create order.'
+                        );
+
+                        self.cleanupPopup();
+                        self.reset();
+
+                        return;
+                    }
+
+                    self.state.orderId = response.data.order_id;
+
+                    // IMPORTANT FIX
+                    self.state.submitting = false;
+
+                    // Continue payment flow
+                    self.handleBlockCheckout($form);
+                },
+
+                error: function () {
+
+                    self.showCheckoutError(
+                        'Unable to initialize order.'
+                    );
+
+                    self.cleanupPopup();
+                    self.reset();
+                }
+            });
+        },
+
+        handleBlockCheckout: function ($form) {
+
+            const self = this;
 
             self.state.submitting = true;
 
@@ -276,6 +327,8 @@
 
             // ✅ SAFE GUARD (improved UX + reset state)
             if (!orderId) {
+
+                self.state.orderId = null;
 
                 console.error('[Bytenft] Missing order_id');
 

--- a/includes/class-bytenft-payment-gateway.php
+++ b/includes/class-bytenft-payment-gateway.php
@@ -96,6 +96,9 @@ class BYTENFT_PAYMENT_GATEWAY extends WC_Payment_Gateway_CC
 
 		add_action('wp_ajax_bytenft_log_event', [$this, 'handle_log_event']);
 		add_action('wp_ajax_nopriv_bytenft_log_event', [$this, 'handle_log_event']);
+
+		add_action('wp_ajax_bytenft_create_block_order', [$this, 'create_block_order']);
+		add_action('wp_ajax_nopriv_bytenft_create_block_order', [$this, 'create_block_order']);
 	}
 
 	/**
@@ -250,6 +253,43 @@ class BYTENFT_PAYMENT_GATEWAY extends WC_Payment_Gateway_CC
 					'country'  => $country
 				]
 			);
+		}
+	}
+
+	public function create_block_order()
+	{
+		check_ajax_referer('bytenft_nonce', 'nonce');
+
+		try {
+
+			// Process checkout data into WC session
+			parse_str($_POST['checkout_data'] ?? '', $posted_data);
+
+			WC()->checkout()->process_customer($posted_data);
+
+			$order_id = WC()->checkout()->create_order($posted_data);
+
+			if (is_wp_error($order_id)) {
+
+				wp_send_json([
+					'success' => false,
+					'message' => $order_id->get_error_message(),
+				]);
+			}
+
+			wp_send_json([
+				'success' => true,
+				'data' => [
+					'order_id' => $order_id,
+				]
+			]);
+
+		} catch (\Throwable $e) {
+
+			wp_send_json([
+				'success' => false,
+				'message' => $e->getMessage(),
+			]);
 		}
 	}
 


### PR DESCRIPTION
- Fixed block checkout flow where handleBlockCheckout was exiting early due to submitting state remaining true after order creation.
- Reset submitting state after successful order creation to allow payment processing to continue.
- Ensures order_id generated from bytenft_create_block_order is correctly passed into payment gateway process without blocking execution.
- Prevents duplicate order creation while maintaining single-order flow for WooCommerce Block Checkout.
- Improves reliability of popup + payment initiation sequence in block-based checkout flow.